### PR TITLE
Melhora a geração do .env e pergunta inicial para usar docker/virtualenv

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -11,17 +11,23 @@
   "package_manager": ["requirements.txt", "pip-tools", "poetry"],
   "python_linter": ["flake8", "pylint", "ruff"],
   "django_api": ["django_only", "django_ninja", "openapi"],
-  "postgresql_version": [
+  "database_version": [
     "postgres:13.3-alpine",
-    "postgis/postgis:14-3.2-alpine",
-    "sqlite3"
+    "postgres:14-alpine",
+    "postgres:15-alpine",
+    "postgis/postgis:14-3.2-alpine"
   ],
+  "use_sqlite_local_env": "no",
   "node_version": ["16.17"],
   "pages_folder_name": ["views", "pages"],
   "api_mock": ["mirageJS", "express"],
   "use_github_actions_CI": "yes",
   "keep_vscode_settings": "yes",
   "keep_vscode_devcontainer": "no",
+  "docker_usage": [
+    "🐳 use docker by default",
+    "📦 use venv npm by default"
+  ],
   "deploy_to": ["local", "fly.io"],
   "deploy_domain": "{{ cookiecutter.project_slug}}.fly.dev",
   "author_name": "Roger Camargo",

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -18,6 +18,7 @@ WARNING = "\x1b[1;33m [WARNING]: "
 INFO = "\x1b[1;33m [INFO]: "
 HINT = "\x1b[3;33m"
 FAIL = "\033[91m"
+GREEN = "\x1b[1;32m "
 SUCCESS = "\x1b[1;32m [SUCCESS]: "
 
 DEBUG_VALUE = "debug"
@@ -157,20 +158,17 @@ def main():
 
     print("What's next?")
     print("  cd {{ cookiecutter.project_slug }}")
-    print("  👉 For DOCKER users 🐳]")
+    print("  👉 For DOCKER users 🐳")
     print("       docker compose build")
-    print("       docker compose -d backend frontend")
+    print("       docker compose up")
     print("       go to http://localhost  (PORT is NOT necessary)")
-    print("       docker compose exec -it backend bash")
-    print("       ./manage.py createsuperuser")
-    print("       pytest\n")
 
-    print("  👉 For frontend devs 😎")
-    print("       WIP\n")
-    print("  👉 For backend devs 🦄]")
-    print("       WIP\n")
+    print("  👉 Using virtualenv 📦")
+    print("       create a virtualenv")
+    print("       install dependencies")
 
-    print(INFO + "⚠️ For more details, check the README\n" + TERMINATOR)
+    print(GREEN + "\n  📄 for more information")
+    print("       https://djavue3.vercel.app\n" + TERMINATOR)
 
 
 if __name__ == "__main__":

--- a/{{cookiecutter.project_slug}}/.env
+++ b/{{cookiecutter.project_slug}}/.env
@@ -8,14 +8,17 @@ POSTGRES_USER={{ cookiecutter.app_name }}
 POSTGRES_PASSWORD={{ cookiecutter.app_name }}
 
 ## 🖥️ Para uso local via virtualenv
-#POSTGRES_HOST=localhost
-#POSTGRES_PORT=15432
-#DATABASE_URL=postgres://core:core@localhost:15432/db_core
+{% if cookiecutter.docker_usage == '🐳 use docker by default' %}#{% endif %}POSTGRES_HOST=localhost
+{% if cookiecutter.docker_usage == '🐳 use docker by default' %}#{% endif %}POSTGRES_PORT=15432
+{% if cookiecutter.docker_usage == '🐳 use docker by default' %}#{% endif %}DATABASE_URL=postgres://{{ cookiecutter.app_name }}:{{ cookiecutter.app_name }}@localhost:15432/db_{{ cookiecutter.app_name }}
+{% if cookiecutter.use_sqlite_local_env == 'yes' %}
+DATABASE_URL=sqlite:///db_local.sqlite3
+{% endif %}
 
 ## 🐳 Para uso via container
-POSTGRES_HOST=postgres
-POSTGRES_PORT=5432
-DATABASE_URL=postgres://core:core@postgres:5432/db_core
+{% if cookiecutter.docker_usage == '📦 use venv npm by default' %}#{% endif %}POSTGRES_HOST=postgres
+{% if cookiecutter.docker_usage == '📦 use venv npm by default' %}#{% endif %}POSTGRES_PORT=5432
+{% if cookiecutter.docker_usage == '📦 use venv npm by default' %}#{% endif %}DATABASE_URL=postgres://{{ cookiecutter.app_name }}:{{ cookiecutter.app_name }}@postgres:5432/db_{{ cookiecutter.app_name }}
 
 # Para funcionar local
 ALLOWED_HOSTS=localhost,backend

--- a/{{cookiecutter.project_slug}}/docker-compose.yml
+++ b/{{cookiecutter.project_slug}}/docker-compose.yml
@@ -20,7 +20,7 @@ services:
         condition: service_healthy
 
   postgres:
-    image: "{{cookiecutter.postgresql_version}}"
+    image: "{{cookiecutter.database_version}}"
     ports:
       - 15432:5432
     expose:

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/base/templates/base/apihome.html
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/base/templates/base/apihome.html
@@ -18,8 +18,12 @@
         <h1>Bem-vindo</h1>
         <h2>Este é o backend Django 🦄</h2>
         <h3>Acesse <a href="/api/docs">/api/docs</a> para ver a documentação da API</h3>
+        {% if cookiecutter.django_api == 'django_only' %}
+        <p>👉 (OPS! django_only não tem docs da API, use a opção django ninja 🥷)</p>
+        {% endif %}
         <h3>Acesse o frontend (outro 📦 container, outro 🚀 deploy)</h3>
         <p>Criado com 🐈‍⬛ <a href="https://github.com/evolutio/djavue3">Djàvue</a></p>
+        <p>Mais informaçoes: <a href="https://djavue3.vercel.app/">https://djavue3.vercel.app/</a></p>
     </main>
 </body>
 


### PR DESCRIPTION
Melhora a geração do .env
desta forma:
- se docker_usage = use docker by default vai deixar comentado localhost
- se docker_usage = use venv npm by default usa o localhost no DATABASE_URL

Também foi adicionado `"use_sqlite_local_env": "no",` que permite subir o backend sem precisar ter docker para subir o postgres