### PR TITLE
Issue #64 fix na camada da API para passar nos testes no django only

### DIFF
--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/base/middlewares.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/base/middlewares.py
@@ -1,0 +1,21 @@
+from django.http import JsonResponse
+from ..base.exceptions import BusinessError
+
+
+class DjavueApiErrorHandlingMiddleware:
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        response = self.get_response(request)
+        return response
+
+    def process_exception(self, request, exc):
+        error = str(exc)
+        if isinstance(exc, ValueError):
+            response = JsonResponse({"message": f"[INVALID INPUT] {error}"}, status=422)
+        elif isinstance(exc, BusinessError):
+            response = JsonResponse({"message": f"[ERROR] {error}"}, status=400)
+        else:
+            response = JsonResponse({"message": f"[UNAVAILABLE] Me desculpe! Serviço não disponível no momento. Tente mais tarde: {error}"}, status=503)
+        return response

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/{{cookiecutter.app_name}}/views.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/{{cookiecutter.app_name}}/views.py
@@ -10,6 +10,7 @@ from ninja import Router
 
 from .schemas import List{{cookiecutter.model}}Schema, {{cookiecutter.model_singular}}Schema, {{cookiecutter.model_singular}}SchemaIn
 {% else %}
+from django.views.decorators.http import require_http_methods
 
 from ..commons.django_views_utils import ajax_login_required
 {% endif %}
@@ -32,7 +33,20 @@ def add_{{cookiecutter.model_singular_lower}}(request, {{cookiecutter.model_sing
 @ajax_login_required
 def add_{{cookiecutter.model_singular_lower}}(request):
     body = json.loads(request.body)
-    new_{{cookiecutter.model_singular_lower}} = {{cookiecutter.model_lower}}_svc.add_{{cookiecutter.model_singular_lower}}(body.get("description"))
+    description = body.get("description")
+
+    if not description:
+        raise ValueError("body.{{cookiecutter.model_singular_lower}}.description: field required (value_error.missing)")
+    if type(description) not in [str, int]:
+        raise ValueError("body.{{cookiecutter.model_singular_lower}}.description: str type expected (type_error.str)")
+
+    description = str(description)
+    if len(description) <= 2:
+        raise ValueError(
+            "body.{{cookiecutter.model_singular_lower}}.description: It must be at least 3 characteres long. (value_error)"
+        )
+
+    new_{{cookiecutter.model_singular_lower}} = {{cookiecutter.model_lower}}_svc.add_{{cookiecutter.model_singular_lower}}(description)
 {% endif %}
     return JsonResponse(new_{{cookiecutter.model_singular_lower}}, status=201)
 
@@ -40,6 +54,7 @@ def add_{{cookiecutter.model_singular_lower}}(request):
 {% if cookiecutter.django_api == "🥷 django_ninja" %}
 @router.get("/{{cookiecutter.model_lower}}/list", response=List{{cookiecutter.model}}Schema)
 {% else %}
+@require_http_methods(["GET"])
 @ajax_login_required
 {% endif %}
 def list_{{cookiecutter.model_lower}}(request):

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/settings.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/settings.py
@@ -85,7 +85,8 @@ MIDDLEWARE = [
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
-    "django.middleware.clickjacking.XFrameOptionsMiddleware",
+    "django.middleware.clickjacking.XFrameOptionsMiddleware",{% if cookiecutter.django_api == "🦄 django_only" %}
+    "{{cookiecutter.project_slug}}.base.middlewares.DjavueApiErrorHandlingMiddleware",{% endif %}
 ]
 
 # CORS


### PR DESCRIPTION
Com o PR anterior da melhoria dos testes. Quando escolhemos a opção "django_only" os testes estavam falhando na camada da API - mensagens de validação